### PR TITLE
Fixing memoryLeak with CGImageRef

### DIFF
--- a/MZCroppableView/Classes/MZCroppableView.m
+++ b/MZCroppableView/Classes/MZCroppableView.m
@@ -127,6 +127,10 @@
     
     maskedImage = [UIImage imageWithCGImage:imageRef];
     
+    // Release the imageRef to prevent a memory leak. CG classes don't use ARC
+    CGImageRelease(imageRef);
+    imageRef = NULL;
+    
     return maskedImage;
 }
 #pragma mark - Touch Methods -


### PR DESCRIPTION
This fixes issue #4 https://github.com/mzeeshanid/MZCroppableView/issues/4
